### PR TITLE
Fix jquery.hotkeys version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "jquery": ">= 1.9.1",
-    "jquery.hotkeys": ">= 1.0",
+    "jquery.hotkeys": "*",
     "fontawesome": ">= 3.0.0",
     "bootstrap": ">= 2.0",
     "google-code-prettify": ">= 1.0.1"


### PR DESCRIPTION
jquery.hotkeys does not seem to have any versions in the repo, which causes bower install to fail, remove the version requirement
