### PR TITLE
update jquery hotkeys dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "jquery": ">= 1.9.1",
-    "jquery.hotkeys": "https://github.com/tzuryby/jquery.hotkeys.git#master",
+    "jquery.hotkeys": "https://github.com/jeresig/jquery.hotkeys.git#master",
     "fontawesome": ">= 3.0.0",
     "bootstrap": ">= 2.0",
     "google-code-prettify": ">= 1.0.1"

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "jquery": ">= 1.9.1",
-    "jquery.hotkeys": "*",
+    "jquery.hotkeys": "https://github.com/tzuryby/jquery.hotkeys.git#master",
     "fontawesome": ">= 3.0.0",
     "bootstrap": ">= 2.0",
     "google-code-prettify": ">= 1.0.1"


### PR DESCRIPTION
This is a pull request for Issue #16. It simply points jquery.hotkeys to the full git endpoint until that user updates their library to be more bower compatible.