### PR TITLE
Fixed typo and version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bootstrap-wysiwyg
 =================
 
-Tiny Bootstrap and JQuery Based WISWYG rich text editor based on browser execCommand.
+Tiny Bootstrap and JQuery Based WYSIWYG rich text editor based on browser execCommand.
 
 Originally built for [MindMup](http://www.mindmup.com).
 

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -3,7 +3,7 @@
  *
  * "Name"    = 'bootstrap-wysiwyg'
  * "Author"  = 'Various, see LICENCE'
- * "Version" = '1.0.1'
+ * "Version" = '1.0.3-beta'
  * "About"   = 'Tiny Bootstrap and JQuery Based WISWYG rich text editor.'
  */
 (function ($) {


### PR DESCRIPTION
The version number was now only out of date but was also misleading. Since the master branch is also the development branch it is misleading to not add the beta tag to the version number. This PR fixes that by updating the version number from 1.0.1 to 1.0.3-beta.

This PR also fixes a type in the README.