### PR TITLE
Bower install fix 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-wysiwyg",
   "description": "A tiny Bootstrap and jQuery based WYSIWYG rich text editor based on the browser function execCommand.",
-  "version": "1.0.3-beta",
+  "version": "1.0.4",
   "keywords": [
     "css",
     "js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-wysiwyg",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "A tiny Bootstrap and jQuery based WYSIWYG rich text editor based on the browser function execCommand.",
   "dependencies": {
   },

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -3,7 +3,7 @@
  *
  * "Name"    = 'bootstrap-wysiwyg'
  * "Author"  = 'Various, see LICENCE'
- * "Version" = '1.0.3-beta'
+ * "Version" = '1.0.4'
  * "About"   = 'A tiny Bootstrap and jQuery based WYSIWYG rich text editor based on the browser function execCommand.'
  */
 (function ($) {

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -2,7 +2,7 @@
  * Provides full Bootstrap based, multi-instance WYSIWYG editor.
  *
  * "Name"    = 'bootstrap-wysiwyg'
- * "Author"  = 'Various, see LICENCE'
+ * "Author"  = 'Various, see LICENSE'
  * "Version" = '1.0.4'
  * "About"   = 'A tiny Bootstrap and jQuery based WYSIWYG rich text editor based on the browser function execCommand.'
  */


### PR DESCRIPTION
Fix for issue #28  
It appears that the [Bower registry](https://bower.herokuapp.com) is pointing to the last release which doesn't contain a [prerelease tag](https://github.com/npm/node-semver#prerelease-tags), which is release [1.0.2](https://github.com/steveathon/bootstrap-wysiwyg/releases/tag/1.0.2). That particular release still contained the bower dependency
`"jquery.hotkeys": ">= 1.0"` which is what causes the error. 
Since that particular dependency issue has been resolved [previously](https://github.com/steveathon/bootstrap-wysiwyg/commit/2485ef2ca2718932ad396c47c36b84784fc64c6a), all that should be required to fix this bug is bumping the package version and issuing a release using a semver compliant, non-prerelease tagged version number. 