### PR TITLE
Allow for disabling hotkey commands

### DIFF
--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -158,6 +158,8 @@
      Wysiwyg.prototype.bindHotkeys = function( editor, options, toolbarBtnSelector ) {
         var self = this;
         $.each( options.hotKeys, function( hotkey, command ) {
+            if(!command) return;
+            
             $( editor ).keydown( hotkey, function( e ) {
                 if ( editor.attr( "contenteditable" ) && $( editor ).is( ":visible" ) ) {
                     e.preventDefault();


### PR DESCRIPTION
I need the ability to un-register hotkey presses.  Specifically, we want tabs to not indent, but focus on the next element... we want the editor to behave more like a native component.

With this PR, I can un-register hotkey presses by registering nothing:

```js
$editor.wysiwyg({
    hotKeys: {
        'tab': ''
    }
});
```