### PR TITLE
Moved the Basic Usage documenation from the README to it's own wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,107 +28,6 @@ Features
 * Supports image capture on mobile devices
 * Events
 
-Basic Usage
------------
-
-```javascript
-$('#editor').wysiwyg();
-```
-
-Don't forget to style your editor div:
-
-```css
-#editor {overflow:scroll; max-height:300px}
-```
-
-If you want to use this for a mobile web site, make sure to read about [how to style it](https://github.com/mindmup/bootstrap-wysiwyg#styling-for-mobile-devices) to optimise mobile screen usage and experience (please note that this demo page isn't optimised for mobile access).
-
-Optionally, also create a toolbar (see the source of this page for an example):
-
-```html
-<div class="btn-toolbar" data-role="editor-toolbar"
-        data-target="#editor">
-  ...
-</div> 
-```
-
-In the toolbar, execute simple commands by adding a data-edit attribute to a link.
-
-```html
-<a data-edit="bold">...</a>
-```
-
-execute more complex commands by adding an argument after a blank or providing an input with a data-edit command (the input value is used as an argument). In case of file inputs, the file contents are read in using the FileReader API and used as the command value.
-
-```html
-<a data-edit="fontName Arial">...</a>
-...
-<input type="text" data-edit="createLink"/>
-...
-<input type="file" data-edit="insertImage" />
-```
-
-Use standard jQuery methods to access and set content and focus. You can also ask for cleaned up HTML content:
-
-```javascript
-$('#editor').cleanHtml()
-```
-
-Customising
------------
-You can assign commands to hotkeys and toolbar links. For a toolbar link, just put the execCommand command name into a data-edit attribute.
-For more info on execCommand, see the [QuirksMode](http://www.quirksmode.org/dom/execCommand.html) and [Mozilla Developer](https://developer.mozilla.org/en/docs/Rich-Text_Editing_in_Mozilla) documentation.
-
-```html
-<div class="btn-toolbar" data-role="editor-toolbar" data-target="#editor">
-  <a class="btn btn-large" data-edit="bold"><i class="icon-bold"></i></a>
-</div>
-```
-
-To pass arguments to a command, separate a command with a space.
-
-```html
-  <a data-edit="fontName Arial">...</a>
-```
-
-You can also use input type='text' with a data-edit attribute. When the value
-is changed, the command from the data-edit attribute will be applied using the
-input value as the command argument
-
-```html
-<input type="text" data-edit="createLink">
-```
-If the input type is file, when a file is selected the contents will be read in using the FileReader API and the data URL will be used as the argument
-
-```html
-<input type="file" data-edit="insertImage">
-```
-
-To change hotkeys, specify the map of hotkeys to commands in the hotKeys option. For example:
-
-```javascript
-$('#editor').wysiwyg({
-  hotKeys: {
-    'ctrl+b meta+b': 'bold',
-    'ctrl+i meta+i': 'italic',
-    'ctrl+u meta+u': 'underline',
-    'ctrl+z meta+z': 'undo',
-    'ctrl+y meta+y meta+shift+z': 'redo'
-  }
-});
-```
-
-Events
-------
-
-#### Change
-Fired whenever anything changes. See this example [events.html](examples/events.html)
-```javascript
-$('#editor').wysiwyg().on('change', function(){
-	alert('something has been changed on the editor');
-});
-```
-
 Styling for mobile devices
 --------------------------
 
@@ -144,6 +43,10 @@ For the content attachment editor on MindMup, we apply the following rules to mo
 - on landscape screens, edit box size is 30% of the screen
 - as the screen gets smaller, non-critical toolbar buttons get hidden into a "other" menu
 
+How to Get Started
+-----------
+To learn the basics of the boostrap-wysiwyg editor, please refer to the project's [Getting Started wiki article](https://github.com/steveathon/bootstrap-wysiwyg/wiki/Getting-Started).
+
 Dependencies
 ------------
 * [jQuery](http://jquery.com/)
@@ -152,8 +55,8 @@ Dependencies
 
 Thanks to
 ------------
-@gojko 					@mindmup			@jordanh
-@beatnbite				@brutuscat			@VictorBjelkholm
+@gojko 					@mindmup			  @jordanh
+@beatnbite			@brutuscat			@VictorBjelkholm
 @mrmrs 					@tilleryd 			@pnevels
 
 History


### PR DESCRIPTION
Per our previous discussion I've moved the basic usage documentation out of the README and put it in it's own wiki article. This way as we add things like new features (like a plugin system) we can use the wiki as a place to give user's additional information on how to use the feature.
