### PR TITLE
Convert Google Prettify.js Links to CDN Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ Use standard jQuery methods to access and set content and focus. You can also as
 $('#editor').cleanHtml()
 ```
 
+Multiple Editors on the Same Page
+-----------
+You can initialize and use multiple instances of the editor on the same page, however, each editor specified in HTML must have a unique `data-role` specified.
+
+For example:
+```html
+<div class="btn-toolbar editorToolbar" data-role="editor-toolbar_editor1" data-target...
+```
+
+Then initialize the editor in Javascript with the unique value assigned to the toolbar:
+```javascript
+$('#editor').wysiwyg({
+        toolbarSelector: '[data-role=editor-toolbar_editor1]'
+    });
+```
+
 Customising
 -----------
 You can assign commands to hotkeys and toolbar links. For a toolbar link, just put the execCommand command name into a data-edit attribute.

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -13,7 +12,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 	</head>
 	<body>

--- a/examples/clear-formatting.html
+++ b/examples/clear-formatting.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -95,7 +94,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#editor').wysiwyg();

--- a/examples/events.html
+++ b/examples/events.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -94,7 +93,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#editor').wysiwyg().on('change', function()

--- a/examples/form-post.html
+++ b/examples/form-post.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />	
@@ -97,7 +96,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#editor').wysiwyg(

--- a/examples/formatblock-example.html
+++ b/examples/formatblock-example.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -107,7 +106,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#editor').wysiwyg();

--- a/examples/html-editor.html
+++ b/examples/html-editor.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>	
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -94,7 +93,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#editor').wysiwyg();

--- a/examples/multiple-editors.html
+++ b/examples/multiple-editors.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -188,7 +187,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#first-editor').wysiwyg();

--- a/examples/simple-toolbar.html
+++ b/examples/simple-toolbar.html
@@ -5,7 +5,6 @@
     	<meta http-equiv="X-UA-Compatible" content="IE=edge">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>A tiny, opensource, Bootstrap WYSIWYG rich text editor</title>
-		<link href="../bower_components/google-code-prettify/src/prettify.css" rel="stylesheet" />
 		<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
 		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet" />
 		<link href="../css/style.css" rel="stylesheet" />
@@ -92,7 +91,7 @@
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 		<script src="../bower_components/jquery.hotkeys/jquery.hotkeys.js"></script>
 		<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-		<script src="../bower_components/google-code-prettify/src/prettify.js"></script>
+		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script src="../src/bootstrap-wysiwyg.js"></script>
 		<script type='text/javascript'>
 			$('#editor').wysiwyg();


### PR DESCRIPTION
Convert Google code-prettify links to use CDN and the new preferred
method of loading: run_prettify.js which no longer requires separate
includes of prettify.css

Addresses issue #115 