### PR TITLE
Attempt to fix hyperlink issue on Edge/IE

### DIFF
--- a/examples/simple-toolbar.html
+++ b/examples/simple-toolbar.html
@@ -14,7 +14,6 @@
 	<body>
 		<div class="container">
 			<h1>Simple Editor with Toolbar</h1>
-			<button id="test" type="button">test</button>
 			<div class="btn-toolbar" data-role="editor-toolbar" data-target="#editor">
 				<div class="btn-group">
 					<a class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Font Size"><i class="fa fa-text-height"></i>&nbsp;<b class="caret"></b></a>
@@ -65,7 +64,7 @@
 					<a class="btn btn-default" data-edit="justifyright" title="Align Right (Ctrl/Cmd+R)"><i class="fa fa-align-right"></i></a>
 					<a class="btn btn-default" data-edit="justifyfull" title="Justify (Ctrl/Cmd+J)"><i class="fa fa-align-justify"></i></a>
 				</div>
-				<div class="btn-group dropdown">
+				<div class="btn-group">
 						<a class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Hyperlink"><i class="fa fa-link"></i></a>
 						<div class="dropdown-menu input-append">
 							<input placeholder="URL" type="text" data-edit="createLink" />

--- a/examples/simple-toolbar.html
+++ b/examples/simple-toolbar.html
@@ -14,6 +14,7 @@
 	<body>
 		<div class="container">
 			<h1>Simple Editor with Toolbar</h1>
+			<button id="test" type="button">test</button>
 			<div class="btn-toolbar" data-role="editor-toolbar" data-target="#editor">
 				<div class="btn-group">
 					<a class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Font Size"><i class="fa fa-text-height"></i>&nbsp;<b class="caret"></b></a>
@@ -64,7 +65,7 @@
 					<a class="btn btn-default" data-edit="justifyright" title="Align Right (Ctrl/Cmd+R)"><i class="fa fa-align-right"></i></a>
 					<a class="btn btn-default" data-edit="justifyfull" title="Justify (Ctrl/Cmd+J)"><i class="fa fa-align-justify"></i></a>
 				</div>
-				<div class="btn-group">
+				<div class="btn-group dropdown">
 						<a class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Hyperlink"><i class="fa fa-link"></i></a>
 						<div class="dropdown-menu input-append">
 							<input placeholder="URL" type="text" data-edit="createLink" />

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -259,6 +259,21 @@
         this.saveSelection(  );
      };
 
+     //Move selection to a particular element
+     function selectElementContents(element) {
+        if (window.getSelection && document.createRange) {
+            var selection = window.getSelection();
+            var range = document.createRange();
+            range.selectNodeContents(element);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        } else if (document.selection && document.body.createTextRange) {
+            var textRange = document.body.createTextRange();
+            textRange.moveToElementText(element);
+            textRange.select();
+        }
+    }
+
      Wysiwyg.prototype.bindToolbar = function( editor, toolbar, options, toolbarBtnSelector ) {
         var self = this;
         toolbar.find( toolbarBtnSelector ).click( function() {
@@ -286,6 +301,14 @@
             var newValue = this.value;  // Ugly but prevents fake double-calls due to selection restoration
             this.value = "";
             self.restoreSelection(  );
+            
+            var text = window.getSelection();
+            if (text.toString().trim() === '' && newValue) {
+                //create selection if there is no selection
+                self.editor.append('<span>' + newValue + '</span>');
+                selectElementContents($('span:last', self.editor)[0]);
+            }
+
             if ( newValue ) {
                 editor.focus();
                 self.execCommand( $( this ).data( options.commandRole ), newValue, editor, options, toolbarBtnSelector );

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -274,10 +274,12 @@
             self.saveSelection(  );
         } );
 
-        toolbar.find( "[data-toggle=dropdown]" ).click( this.restoreSelection(  ) );
+        toolbar.find( "[data-toggle=dropdown]" ).on('click', (function () {
+            self.markSelection(options.selectionColor, options);
+        }));
         
         toolbar.on( "hide.bs.dropdown", function () {
-            self.markSelection( null, false, options );
+            self.markSelection( false, options );
         });
 
         toolbar.find( "input[type=text][data-" + options.commandRole + "]" ).on( "webkitspeechchange change", function() {
@@ -291,9 +293,7 @@
             self.saveSelection(  );
         } ).on( "blur", function() {
             var input = $( this );
-            if ( input.data( options.selectionMarker ) ) {
-                self.markSelection( input, false, options );
-            }
+            self.markSelection( false, options );
         } );
         toolbar.find( "input[type=file][data-" + options.commandRole + "]" ).change( function() {
             self.restoreSelection(  );

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -1,7 +1,6 @@
 /* jshint browser: true */
 
-( function( window, $ )
-{
+(function (window, $) {
     "use strict";
 
     /*
@@ -10,324 +9,350 @@
      *  @param {DOMNode} element - The TEXTAREA element to add the Wysiwyg to.
      *  @param {object} userOptions - The default options selected by the user.
      */
-    function Wysiwyg( element, userOptions ) {
+    function Wysiwyg(element, userOptions) {
 
         // This calls the $ function, with the element as a parameter and
         // returns the jQuery object wrapper for element. It also assigns the
         // jQuery object wrapper to the property $editor on `this`.
         this.selectedRange = null;
-        this.editor = $( element );
-        var editor = $( element );
+        this.editor = $(element);
+        var editor = $(element);
         var defaults = {
             hotKeys: {
-            "Ctrl+b meta+b": "bold",
-            "Ctrl+i meta+i": "italic",
-            "Ctrl+u meta+u": "underline",
-            "Ctrl+z": "undo",
-            "Ctrl+y meta+y meta+shift+z": "redo",
-            "Ctrl+l meta+l": "justifyleft",
-            "Ctrl+r meta+r": "justifyright",
-            "Ctrl+e meta+e": "justifycenter",
-            "Ctrl+j meta+j": "justifyfull",
-            "Shift+tab": "outdent",
-            "tab": "indent"
+                "Ctrl+b meta+b": "bold",
+                "Ctrl+i meta+i": "italic",
+                "Ctrl+u meta+u": "underline",
+                "Ctrl+z": "undo",
+                "Ctrl+y meta+y meta+shift+z": "redo",
+                "Ctrl+l meta+l": "justifyleft",
+                "Ctrl+r meta+r": "justifyright",
+                "Ctrl+e meta+e": "justifycenter",
+                "Ctrl+j meta+j": "justifyfull",
+                "Shift+tab": "outdent",
+                "tab": "indent"
             },
             toolbarSelector: "[data-role=editor-toolbar]",
             commandRole: "edit",
             activeToolbarClass: "btn-info",
             selectionMarker: "edit-focus-marker",
-            selectionColor: "darkgrey",
+            selectionColor: "red",
             dragAndDropImages: true,
             keypressTimeout: 200,
-            fileUploadError: function( reason, detail ) { console.log( "File upload error", reason, detail ); }
+            fileUploadError: function (reason, detail) { console.log("File upload error", reason, detail); }
         };
 
-        var options = $.extend( true, {}, defaults, userOptions );
+        var options = $.extend(true, {}, defaults, userOptions);
         var toolbarBtnSelector = "a[data-" + options.commandRole + "],button[data-" + options.commandRole + "],input[type=button][data-" + options.commandRole + "]";
-        this.bindHotkeys( editor, options, toolbarBtnSelector );
+        this.bindHotkeys(editor, options, toolbarBtnSelector);
 
-        if ( options.dragAndDropImages ) {
-            this.initFileDrops( editor, options, toolbarBtnSelector );
+        if (options.dragAndDropImages) {
+            this.initFileDrops(editor, options, toolbarBtnSelector);
         }
 
-        this.bindToolbar( editor, $( options.toolbarSelector ), options, toolbarBtnSelector );
+        this.bindToolbar(editor, $(options.toolbarSelector), options, toolbarBtnSelector);
 
-        editor.attr( "contenteditable", true )
-            .on( "mouseup keyup mouseout", function() {
+        editor.attr("contenteditable", true)
+            .on("mouseup keyup mouseout", function () {
                 this.saveSelection();
-                this.updateToolbar( editor, toolbarBtnSelector, options );
-            }.bind( this ) );
+                this.updateToolbar(editor, toolbarBtnSelector, options);
+            }.bind(this));
 
-        $( window ).bind( "touchend", function( e ) {
-            var isInside = ( editor.is( e.target ) || editor.has( e.target ).length > 0 ),
-            currentRange = this.getCurrentRange(),
-            clear = currentRange && ( currentRange.startContainer === currentRange.endContainer && currentRange.startOffset === currentRange.endOffset );
+        $(window).bind("touchend", function (e) {
+            var isInside = (editor.is(e.target) || editor.has(e.target).length > 0),
+                currentRange = this.getCurrentRange(),
+                clear = currentRange && (currentRange.startContainer === currentRange.endContainer && currentRange.startOffset === currentRange.endOffset);
 
-            if ( !clear || isInside ) {
+            if (!clear || isInside) {
                 this.saveSelection();
-                this.updateToolbar( editor, toolbarBtnSelector, options );
+                this.updateToolbar(editor, toolbarBtnSelector, options);
             }
-        } );
-     }
+        });
+    }
 
-     Wysiwyg.prototype.readFileIntoDataUrl = function( fileInfo ) {
+    Wysiwyg.prototype.readFileIntoDataUrl = function (fileInfo) {
         var loader = $.Deferred(),
-        fReader = new FileReader();
+            fReader = new FileReader();
 
-        fReader.onload = function( e ) {
-            loader.resolve( e.target.result );
+        fReader.onload = function (e) {
+            loader.resolve(e.target.result);
         };
 
         fReader.onerror = loader.reject;
         fReader.onprogress = loader.notify;
-        fReader.readAsDataURL( fileInfo );
+        fReader.readAsDataURL(fileInfo);
         return loader.promise();
-     };
+    };
 
-     Wysiwyg.prototype.cleanHtml = function( o ) {
+    Wysiwyg.prototype.cleanHtml = function (o) {
         var self = this;
-        if ( $( self ).data( "wysiwyg-html-mode" ) === true ) {
-            $( self ).html( $( self ).text() );
-            $( self ).attr( "contenteditable", true );
-            $( self ).data( "wysiwyg-html-mode", false );
+        if ($(self).data("wysiwyg-html-mode") === true) {
+            $(self).html($(self).text());
+            $(self).attr("contenteditable", true);
+            $(self).data("wysiwyg-html-mode", false);
         }
 
         // Strip the images with src="data:image/.." out;
-        if ( o === true && $( self ).parent().is( "form" ) ) {
-            var gGal = $( self ).html;
-            if ( $( gGal ).has( "img" ).length ) {
-                var gImages = $( "img", $( gGal ) );
+        if (o === true && $(self).parent().is("form")) {
+            var gGal = $(self).html;
+            if ($(gGal).has("img").length) {
+                var gImages = $("img", $(gGal));
                 var gResults = [];
-                var gEditor = $( self ).parent();
-                $.each( gImages, function( i, v ) {
-                    if ( $( v ).attr( "src" ).match( /^data:image\/.*$/ ) ) {
-                        gResults.push( gImages[ i ] );
-                        $( gEditor ).prepend( "<input value='" + $( v ).attr( "src" ) + "' type='hidden' name='postedimage/" + i + "' />" );
-                        $( v ).attr( "src", "postedimage/" + i );
+                var gEditor = $(self).parent();
+                $.each(gImages, function (i, v) {
+                    if ($(v).attr("src").match(/^data:image\/.*$/)) {
+                        gResults.push(gImages[i]);
+                        $(gEditor).prepend("<input value='" + $(v).attr("src") + "' type='hidden' name='postedimage/" + i + "' />");
+                        $(v).attr("src", "postedimage/" + i);
                     }
-                } );
+                });
             }
         }
 
-        var html = $( self ).html();
-        return html && html.replace( /(<br>|\s|<div><br><\/div>|&nbsp;)*$/, "" );
-     };
+        var html = $(self).html();
+        return html && html.replace(/(<br>|\s|<div><br><\/div>|&nbsp;)*$/, "");
+    };
 
-     Wysiwyg.prototype.updateToolbar = function( editor, toolbarBtnSelector, options ) {
-        if ( options.activeToolbarClass ) {
-            $( options.toolbarSelector ).find( toolbarBtnSelector ).each( function() {
-                var self =  $( this );
-                var commandArr = self.data( options.commandRole ).split( " " );
-                var command = commandArr[ 0 ];
+    Wysiwyg.prototype.updateToolbar = function (editor, toolbarBtnSelector, options) {
+        if (options.activeToolbarClass) {
+            $(options.toolbarSelector).find(toolbarBtnSelector).each(function () {
+                var self = $(this);
+                var commandArr = self.data(options.commandRole).split(" ");
+                var command = commandArr[0];
 
                 // If the command has an argument and its value matches this button. == used for string/number comparison
-                if ( commandArr.length > 1 && document.queryCommandEnabled( command ) && document.queryCommandValue( command ) === commandArr[ 1 ] ) {
-                    self.addClass( options.activeToolbarClass );
+                if (commandArr.length > 1 && document.queryCommandEnabled(command) && document.queryCommandValue(command) === commandArr[1]) {
+                    self.addClass(options.activeToolbarClass);
                 }
 
                 // Else if the command has no arguments and it is active
-                else if ( commandArr.length === 1 && document.queryCommandEnabled( command ) && document.queryCommandState( command ) ) {
-                    self.addClass( options.activeToolbarClass );
+                else if (commandArr.length === 1 && document.queryCommandEnabled(command) && document.queryCommandState(command)) {
+                    self.addClass(options.activeToolbarClass);
                 }
 
                 // Else the command is not active
                 else {
-                    self.removeClass( options.activeToolbarClass );
+                    self.removeClass(options.activeToolbarClass);
                 }
-            } );
+            });
         }
-     };
+    };
 
-     Wysiwyg.prototype.execCommand = function( commandWithArgs, valueArg, editor, options, toolbarBtnSelector ) {
-        var commandArr = commandWithArgs.split( " " ),
+    Wysiwyg.prototype.execCommand = function (commandWithArgs, valueArg, editor, options, toolbarBtnSelector) {
+        var commandArr = commandWithArgs.split(" "),
             command = commandArr.shift(),
-            args = commandArr.join( " " ) + ( valueArg || "" );
+            args = commandArr.join(" ") + (valueArg || "");
 
-        var parts = commandWithArgs.split( "-" );
+        var parts = commandWithArgs.split("-");
 
-        if ( parts.length === 1 ) {
-            document.execCommand( command, false, args );
-        } else if ( parts[ 0 ] === "format" && parts.length === 2 ) {
-            document.execCommand( "formatBlock", false, parts[ 1 ] );
+        if (parts.length === 1) {
+            document.execCommand(command, false, args);
+        } else if (parts[0] === "format" && parts.length === 2) {
+            document.execCommand("formatBlock", false, parts[1]);
         }
 
-        ( editor ).trigger( "change" );
-        this.updateToolbar( editor, toolbarBtnSelector, options );
-     };
+        (editor).trigger("change");
+        this.updateToolbar(editor, toolbarBtnSelector, options);
+    };
 
-     Wysiwyg.prototype.bindHotkeys = function( editor, options, toolbarBtnSelector ) {
+    Wysiwyg.prototype.bindHotkeys = function (editor, options, toolbarBtnSelector) {
         var self = this;
-        $.each( options.hotKeys, function( hotkey, command ) {
-            if(!command) return;
-            
-            $( editor ).keydown( hotkey, function( e ) {
-                if ( editor.attr( "contenteditable" ) && $( editor ).is( ":visible" ) ) {
+        $.each(options.hotKeys, function (hotkey, command) {
+            if (!command) return;
+
+            $(editor).keydown(hotkey, function (e) {
+                if (editor.attr("contenteditable") && $(editor).is(":visible")) {
                     e.preventDefault();
                     e.stopPropagation();
-                    self.execCommand( command, null, editor, options, toolbarBtnSelector );
+                    self.execCommand(command, null, editor, options, toolbarBtnSelector);
                 }
-            } ).keyup( hotkey, function( e ) {
-                if ( editor.attr( "contenteditable" ) && $( editor ).is( ":visible" ) ) {
+            }).keyup(hotkey, function (e) {
+                if (editor.attr("contenteditable") && $(editor).is(":visible")) {
                     e.preventDefault();
                     e.stopPropagation();
                 }
-            } );
-        } );
+            });
+        });
 
-        editor.keyup( function() { editor.trigger( "change" ); } );
-     };
+        editor.keyup(function () { editor.trigger("change"); });
+    };
 
-     Wysiwyg.prototype.getCurrentRange = function() {
+    Wysiwyg.prototype.getCurrentRange = function () {
         var sel, range;
-        if ( window.getSelection ) {
+        if (window.getSelection) {
             sel = window.getSelection();
-            if ( sel.getRangeAt && sel.rangeCount ) {
-                range = sel.getRangeAt( 0 );
+            if (sel.getRangeAt && sel.rangeCount) {
+                range = sel.getRangeAt(0);
             }
-        } else if ( document.selection ) {
+        } else if (document.selection) {
             range = document.selection.createRange();
         }
 
         return range;
-     };
+    };
 
-     Wysiwyg.prototype.saveSelection = function() {
+    Wysiwyg.prototype.saveSelection = function () {
         this.selectedRange = this.getCurrentRange();
-     };
+    };
 
-     Wysiwyg.prototype.restoreSelection = function() {
+    Wysiwyg.prototype.restoreSelection = function () {
         var selection;
-        if ( window.getSelection || document.createRange ) {
+        if (window.getSelection || document.createRange) {
             selection = window.getSelection();
-            if ( this.selectedRange ) {
+            if (this.selectedRange) {
                 try {
                     selection.removeAllRanges();
                 }
-                catch ( ex ) {
+                catch (ex) {
                     document.body.createTextRange().select();
                     document.selection.empty();
                 }
-                selection.addRange( this.selectedRange );
+                selection.addRange(this.selectedRange);
             }
-        } else if ( document.selection && this.selectedRange ) {
+        } else if (document.selection && this.selectedRange) {
             this.selectedRange.select();
         }
-     };
+    };
 
-     // Adding Toggle HTML based on the work by @jd0000, but cleaned up a little to work in this context.
-     Wysiwyg.prototype.toggleHtmlEdit = function( editor ) {
-        if ( editor.data( "wysiwyg-html-mode" ) !== true ) {
-            var oContent = editor.html();
-            var editorPre = $( "<pre />" );
-            $( editorPre ).append( document.createTextNode( oContent ) );
-            $( editorPre ).attr( "contenteditable", true );
-            $( editor ).html( " " );
-            $( editor ).append( $( editorPre ) );
-            $( editor ).attr( "contenteditable", false );
-            $( editor ).data( "wysiwyg-html-mode", true );
-            $( editorPre ).focus();
-        } else {
-            $( editor ).html( $( editor ).text() );
-            $( editor ).attr( "contenteditable", true );
-            $( editor ).data( "wysiwyg-html-mode", false );
-            $( editor ).focus();
+    Wysiwyg.prototype.restoreSelection2 = function (inputSel) {
+        var selection;
+        if (window.getSelection || document.createRange) {
+            selection = window.getSelection();
+            if (this.selectedRange) {
+                try {
+                    selection.removeAllRanges();
+                }
+                catch (ex) {
+                    //try adding value here for edge when there is no selection
+                    document.body.createTextRange().select();
+                    document.selection.empty();
+                }
+                selection.addRange(inputSel);
+            }
+        } else if (document.selection && inputSel) {
+            inputSel.select();
         }
-     };
+    };
 
-     Wysiwyg.prototype.insertFiles = function( files, options, editor, toolbarBtnSelector ) {
+    // Adding Toggle HTML based on the work by @jd0000, but cleaned up a little to work in this context.
+    Wysiwyg.prototype.toggleHtmlEdit = function (editor) {
+        if (editor.data("wysiwyg-html-mode") !== true) {
+            var oContent = editor.html();
+            var editorPre = $("<pre />");
+            $(editorPre).append(document.createTextNode(oContent));
+            $(editorPre).attr("contenteditable", true);
+            $(editor).html(" ");
+            $(editor).append($(editorPre));
+            $(editor).attr("contenteditable", false);
+            $(editor).data("wysiwyg-html-mode", true);
+            $(editorPre).focus();
+        } else {
+            $(editor).html($(editor).text());
+            $(editor).attr("contenteditable", true);
+            $(editor).data("wysiwyg-html-mode", false);
+            $(editor).focus();
+        }
+    };
+
+    Wysiwyg.prototype.insertFiles = function (files, options, editor, toolbarBtnSelector) {
         var self = this;
         editor.focus();
-        $.each( files, function( idx, fileInfo ) {
-            if ( /^image\//.test( fileInfo.type ) ) {
-                $.when( self.readFileIntoDataUrl( fileInfo ) ).done( function( dataUrl ) {
-                    self.execCommand( "insertimage", dataUrl, editor, options, toolbarBtnSelector );
-                    editor.trigger( "image-inserted" );
-                } ).fail( function( e ) {
-                    options.fileUploadError( "file-reader", e );
-                } );
+        $.each(files, function (idx, fileInfo) {
+            if (/^image\//.test(fileInfo.type)) {
+                $.when(self.readFileIntoDataUrl(fileInfo)).done(function (dataUrl) {
+                    self.execCommand("insertimage", dataUrl, editor, options, toolbarBtnSelector);
+                    editor.trigger("image-inserted");
+                }).fail(function (e) {
+                    options.fileUploadError("file-reader", e);
+                });
             } else {
-                options.fileUploadError( "unsupported-file-type", fileInfo.type );
+                options.fileUploadError("unsupported-file-type", fileInfo.type);
             }
-        } );
-     };
+        });
+    };
 
-     Wysiwyg.prototype.markSelection = function( input, color, options ) {
-        this.restoreSelection(  );
-        if ( document.queryCommandSupported( "hiliteColor" ) ) {
-            document.execCommand( "hiliteColor", false, color || "transparent" );
+    Wysiwyg.prototype.markSelection = function (input, color, options) {
+        this.restoreSelection();
+        if (document.queryCommandSupported("hiliteColor")) {
+            document.execCommand("hiliteColor", false, color || "transparent");
         }
-        this.saveSelection(  );
-        input.data( options.selectionMarker, color );
-     };
+        this.saveSelection();
+        //input.data(options.selectionMarker, color);
+    };
 
-     Wysiwyg.prototype.bindToolbar = function( editor, toolbar, options, toolbarBtnSelector ) {
+    Wysiwyg.prototype.bindToolbar = function (editor, toolbar, options, toolbarBtnSelector) {
         var self = this;
-        toolbar.find( toolbarBtnSelector ).click( function() {
-            self.restoreSelection(  );
+        toolbar.find(toolbarBtnSelector).click(function () {
+            self.restoreSelection();
             editor.focus();
 
-            if ( editor.data( options.commandRole ) === "html" ) {
-                self.toggleHtmlEdit( editor );
+            if (editor.data(options.commandRole) === "html") {
+                self.toggleHtmlEdit(editor);
             } else {
-                self.execCommand( $( this ).data( options.commandRole ), null, editor, options, toolbarBtnSelector );
+                self.execCommand($(this).data(options.commandRole), null, editor, options, toolbarBtnSelector);
             }
 
-            self.saveSelection(  );
-        } );
+            self.saveSelection();
+        });
 
-        toolbar.find( "[data-toggle=dropdown]" ).click( this.restoreSelection(  ) );
+        toolbar.find("[data-toggle=dropdown]").on('click', (function () {
+            self.restoreSelection();
+            self.markSelection(null, options.selectionColor, options);
+        }));
+        
+        $(".dropdown").on("hide.bs.dropdown", function () {
+            self.markSelection(null, false, options);
+        });
 
-        toolbar.find( "input[type=text][data-" + options.commandRole + "]" ).on( "webkitspeechchange change", function() {
+        toolbar.find("input[type=text][data-" + options.commandRole + "]").on("webkitspeechchange change", function () {
             var newValue = this.value;  // Ugly but prevents fake double-calls due to selection restoration
             this.value = "";
-            self.restoreSelection(  );
-            if ( newValue ) {
+            self.restoreSelection();
+            if (newValue) {
                 editor.focus();
-                self.execCommand( $( this ).data( options.commandRole ), newValue, editor, options, toolbarBtnSelector );
+                self.execCommand($(this).data(options.commandRole), newValue, editor, options, toolbarBtnSelector);
             }
-            self.saveSelection(  );
-        } ).on( "focus", function() {
-            var input = $( this );
-            if ( !input.data( options.selectionMarker ) ) {
-                self.markSelection( input, options.selectionColor, options );
-                input.focus();
+            self.saveSelection();
+        }).on("focus", function () {
+            console.log('focus');
+            var input = $(this);
+            // if (!input.data(options.selectionMarker)) {
+            //     self.markSelection(input, options.selectionColor, options);
+            // }
+        }).on("blur", function () {
+            console.log('blur');
+            var input = $(this);
+            self.markSelection(input, false, options);
+        });
+        toolbar.find("input[type=file][data-" + options.commandRole + "]").change(function () {
+            self.restoreSelection();
+            if (this.type === "file" && this.files && this.files.length > 0) {
+                self.insertFiles(this.files, options, editor, toolbarBtnSelector);
             }
-        } ).on( "blur", function() {
-            var input = $( this );
-            if ( input.data( options.selectionMarker ) ) {
-                self.markSelection( input, false, options );
-            }
-        } );
-        toolbar.find( "input[type=file][data-" + options.commandRole + "]" ).change( function() {
-            self.restoreSelection(  );
-            if ( this.type === "file" && this.files && this.files.length > 0 ) {
-                self.insertFiles( this.files, options, editor, toolbarBtnSelector );
-            }
-            self.saveSelection(  );
+            self.saveSelection();
             this.value = "";
-        } );
-     };
+        });
+    };
 
-     Wysiwyg.prototype.initFileDrops = function( editor, options, toolbarBtnSelector ) {
-         var self = this;
-        editor.on( "dragenter dragover", false ).on( "drop", function( e ) {
+    Wysiwyg.prototype.initFileDrops = function (editor, options, toolbarBtnSelector) {
+        var self = this;
+        editor.on("dragenter dragover", false).on("drop", function (e) {
             var dataTransfer = e.originalEvent.dataTransfer;
             e.stopPropagation();
             e.preventDefault();
-            if ( dataTransfer && dataTransfer.files && dataTransfer.files.length > 0 ) {
-                self.insertFiles( dataTransfer.files, options, editor, toolbarBtnSelector );
+            if (dataTransfer && dataTransfer.files && dataTransfer.files.length > 0) {
+                self.insertFiles(dataTransfer.files, options, editor, toolbarBtnSelector);
             }
-        } );
-     };
+        });
+    };
 
-     /*
-      *  Represenets an editor
-      *  @constructor
-      *  @param {object} userOptions - The default options selected by the user.
-      */
+    /*
+     *  Represenets an editor
+     *  @constructor
+     *  @param {object} userOptions - The default options selected by the user.
+     */
 
-     $.fn.wysiwyg = function( userOptions ) {
-        var wysiwyg = new Wysiwyg( this, userOptions );
-     };
+    $.fn.wysiwyg = function (userOptions) {
+        var wysiwyg = new Wysiwyg(this, userOptions);
+    };
 
-} )( window, window.jQuery );
+})(window, window.jQuery);

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -1,6 +1,7 @@
 /* jshint browser: true */
 
-(function (window, $) {
+( function( window, $ )
+{
     "use strict";
 
     /*
@@ -9,27 +10,27 @@
      *  @param {DOMNode} element - The TEXTAREA element to add the Wysiwyg to.
      *  @param {object} userOptions - The default options selected by the user.
      */
-    function Wysiwyg(element, userOptions) {
+    function Wysiwyg( element, userOptions ) {
 
         // This calls the $ function, with the element as a parameter and
         // returns the jQuery object wrapper for element. It also assigns the
         // jQuery object wrapper to the property $editor on `this`.
         this.selectedRange = null;
-        this.editor = $(element);
-        var editor = $(element);
+        this.editor = $( element );
+        var editor = $( element );
         var defaults = {
             hotKeys: {
-                "Ctrl+b meta+b": "bold",
-                "Ctrl+i meta+i": "italic",
-                "Ctrl+u meta+u": "underline",
-                "Ctrl+z": "undo",
-                "Ctrl+y meta+y meta+shift+z": "redo",
-                "Ctrl+l meta+l": "justifyleft",
-                "Ctrl+r meta+r": "justifyright",
-                "Ctrl+e meta+e": "justifycenter",
-                "Ctrl+j meta+j": "justifyfull",
-                "Shift+tab": "outdent",
-                "tab": "indent"
+            "Ctrl+b meta+b": "bold",
+            "Ctrl+i meta+i": "italic",
+            "Ctrl+u meta+u": "underline",
+            "Ctrl+z": "undo",
+            "Ctrl+y meta+y meta+shift+z": "redo",
+            "Ctrl+l meta+l": "justifyleft",
+            "Ctrl+r meta+r": "justifyright",
+            "Ctrl+e meta+e": "justifycenter",
+            "Ctrl+j meta+j": "justifyfull",
+            "Shift+tab": "outdent",
+            "tab": "indent"
             },
             toolbarSelector: "[data-role=editor-toolbar]",
             commandRole: "edit",
@@ -38,301 +39,292 @@
             selectionColor: "darkgrey",
             dragAndDropImages: true,
             keypressTimeout: 200,
-            fileUploadError: function (reason, detail) { console.log("File upload error", reason, detail); }
+            fileUploadError: function( reason, detail ) { console.log( "File upload error", reason, detail ); }
         };
 
-        var options = $.extend(true, {}, defaults, userOptions);
+        var options = $.extend( true, {}, defaults, userOptions );
         var toolbarBtnSelector = "a[data-" + options.commandRole + "],button[data-" + options.commandRole + "],input[type=button][data-" + options.commandRole + "]";
-        this.bindHotkeys(editor, options, toolbarBtnSelector);
+        this.bindHotkeys( editor, options, toolbarBtnSelector );
 
-        if (options.dragAndDropImages) {
-            this.initFileDrops(editor, options, toolbarBtnSelector);
+        if ( options.dragAndDropImages ) {
+            this.initFileDrops( editor, options, toolbarBtnSelector );
         }
 
-        this.bindToolbar(editor, $(options.toolbarSelector), options, toolbarBtnSelector);
+        this.bindToolbar( editor, $( options.toolbarSelector ), options, toolbarBtnSelector );
 
-        editor.attr("contenteditable", true)
-            .on("mouseup keyup mouseout", function () {
+        editor.attr( "contenteditable", true )
+            .on( "mouseup keyup mouseout", function() {
                 this.saveSelection();
-                this.updateToolbar(editor, toolbarBtnSelector, options);
-            }.bind(this));
+                this.updateToolbar( editor, toolbarBtnSelector, options );
+            }.bind( this ) );
 
-        $(window).bind("touchend", function (e) {
-            var isInside = (editor.is(e.target) || editor.has(e.target).length > 0),
-                currentRange = this.getCurrentRange(),
-                clear = currentRange && (currentRange.startContainer === currentRange.endContainer && currentRange.startOffset === currentRange.endOffset);
+        $( window ).bind( "touchend", function( e ) {
+            var isInside = ( editor.is( e.target ) || editor.has( e.target ).length > 0 ),
+            currentRange = this.getCurrentRange(),
+            clear = currentRange && ( currentRange.startContainer === currentRange.endContainer && currentRange.startOffset === currentRange.endOffset );
 
-            if (!clear || isInside) {
+            if ( !clear || isInside ) {
                 this.saveSelection();
-                this.updateToolbar(editor, toolbarBtnSelector, options);
+                this.updateToolbar( editor, toolbarBtnSelector, options );
             }
-        });
-    }
+        } );
+     }
 
-    Wysiwyg.prototype.readFileIntoDataUrl = function (fileInfo) {
+     Wysiwyg.prototype.readFileIntoDataUrl = function( fileInfo ) {
         var loader = $.Deferred(),
-            fReader = new FileReader();
+        fReader = new FileReader();
 
-        fReader.onload = function (e) {
-            loader.resolve(e.target.result);
+        fReader.onload = function( e ) {
+            loader.resolve( e.target.result );
         };
 
         fReader.onerror = loader.reject;
         fReader.onprogress = loader.notify;
-        fReader.readAsDataURL(fileInfo);
+        fReader.readAsDataURL( fileInfo );
         return loader.promise();
-    };
+     };
 
-    Wysiwyg.prototype.cleanHtml = function (o) {
+     Wysiwyg.prototype.cleanHtml = function( o ) {
         var self = this;
-        if ($(self).data("wysiwyg-html-mode") === true) {
-            $(self).html($(self).text());
-            $(self).attr("contenteditable", true);
-            $(self).data("wysiwyg-html-mode", false);
+        if ( $( self ).data( "wysiwyg-html-mode" ) === true ) {
+            $( self ).html( $( self ).text() );
+            $( self ).attr( "contenteditable", true );
+            $( self ).data( "wysiwyg-html-mode", false );
         }
 
         // Strip the images with src="data:image/.." out;
-        if (o === true && $(self).parent().is("form")) {
-            var gGal = $(self).html;
-            if ($(gGal).has("img").length) {
-                var gImages = $("img", $(gGal));
+        if ( o === true && $( self ).parent().is( "form" ) ) {
+            var gGal = $( self ).html;
+            if ( $( gGal ).has( "img" ).length ) {
+                var gImages = $( "img", $( gGal ) );
                 var gResults = [];
-                var gEditor = $(self).parent();
-                $.each(gImages, function (i, v) {
-                    if ($(v).attr("src").match(/^data:image\/.*$/)) {
-                        gResults.push(gImages[i]);
-                        $(gEditor).prepend("<input value='" + $(v).attr("src") + "' type='hidden' name='postedimage/" + i + "' />");
-                        $(v).attr("src", "postedimage/" + i);
+                var gEditor = $( self ).parent();
+                $.each( gImages, function( i, v ) {
+                    if ( $( v ).attr( "src" ).match( /^data:image\/.*$/ ) ) {
+                        gResults.push( gImages[ i ] );
+                        $( gEditor ).prepend( "<input value='" + $( v ).attr( "src" ) + "' type='hidden' name='postedimage/" + i + "' />" );
+                        $( v ).attr( "src", "postedimage/" + i );
                     }
-                });
+                } );
             }
         }
 
-        var html = $(self).html();
-        return html && html.replace(/(<br>|\s|<div><br><\/div>|&nbsp;)*$/, "");
-    };
+        var html = $( self ).html();
+        return html && html.replace( /(<br>|\s|<div><br><\/div>|&nbsp;)*$/, "" );
+     };
 
-    Wysiwyg.prototype.updateToolbar = function (editor, toolbarBtnSelector, options) {
-        if (options.activeToolbarClass) {
-            $(options.toolbarSelector).find(toolbarBtnSelector).each(function () {
-                var self = $(this);
-                var commandArr = self.data(options.commandRole).split(" ");
-                var command = commandArr[0];
+     Wysiwyg.prototype.updateToolbar = function( editor, toolbarBtnSelector, options ) {
+        if ( options.activeToolbarClass ) {
+            $( options.toolbarSelector ).find( toolbarBtnSelector ).each( function() {
+                var self =  $( this );
+                var commandArr = self.data( options.commandRole ).split( " " );
+                var command = commandArr[ 0 ];
 
                 // If the command has an argument and its value matches this button. == used for string/number comparison
-                if (commandArr.length > 1 && document.queryCommandEnabled(command) && document.queryCommandValue(command) === commandArr[1]) {
-                    self.addClass(options.activeToolbarClass);
+                if ( commandArr.length > 1 && document.queryCommandEnabled( command ) && document.queryCommandValue( command ) === commandArr[ 1 ] ) {
+                    self.addClass( options.activeToolbarClass );
                 }
 
                 // Else if the command has no arguments and it is active
-                else if (commandArr.length === 1 && document.queryCommandEnabled(command) && document.queryCommandState(command)) {
-                    self.addClass(options.activeToolbarClass);
+                else if ( commandArr.length === 1 && document.queryCommandEnabled( command ) && document.queryCommandState( command ) ) {
+                    self.addClass( options.activeToolbarClass );
                 }
 
                 // Else the command is not active
                 else {
-                    self.removeClass(options.activeToolbarClass);
+                    self.removeClass( options.activeToolbarClass );
                 }
-            });
+            } );
         }
-    };
+     };
 
-    Wysiwyg.prototype.execCommand = function (commandWithArgs, valueArg, editor, options, toolbarBtnSelector) {
-        var commandArr = commandWithArgs.split(" "),
+     Wysiwyg.prototype.execCommand = function( commandWithArgs, valueArg, editor, options, toolbarBtnSelector ) {
+        var commandArr = commandWithArgs.split( " " ),
             command = commandArr.shift(),
-            args = commandArr.join(" ") + (valueArg || "");
+            args = commandArr.join( " " ) + ( valueArg || "" );
 
-        var parts = commandWithArgs.split("-");
+        var parts = commandWithArgs.split( "-" );
 
-        if (parts.length === 1) {
-            document.execCommand(command, false, args);
-        } else if (parts[0] === "format" && parts.length === 2) {
-            document.execCommand("formatBlock", false, parts[1]);
+        if ( parts.length === 1 ) {
+            document.execCommand( command, false, args );
+        } else if ( parts[ 0 ] === "format" && parts.length === 2 ) {
+            document.execCommand( "formatBlock", false, parts[ 1 ] );
         }
 
-        (editor).trigger("change");
-        this.updateToolbar(editor, toolbarBtnSelector, options);
-    };
+        ( editor ).trigger( "change" );
+        this.updateToolbar( editor, toolbarBtnSelector, options );
+     };
 
-    Wysiwyg.prototype.bindHotkeys = function (editor, options, toolbarBtnSelector) {
+     Wysiwyg.prototype.bindHotkeys = function( editor, options, toolbarBtnSelector ) {
         var self = this;
-        $.each(options.hotKeys, function (hotkey, command) {
-            if (!command) return;
-
-            $(editor).keydown(hotkey, function (e) {
-                if (editor.attr("contenteditable") && $(editor).is(":visible")) {
+        $.each( options.hotKeys, function( hotkey, command ) {
+            if(!command) return;
+            
+            $( editor ).keydown( hotkey, function( e ) {
+                if ( editor.attr( "contenteditable" ) && $( editor ).is( ":visible" ) ) {
                     e.preventDefault();
                     e.stopPropagation();
-                    self.execCommand(command, null, editor, options, toolbarBtnSelector);
+                    self.execCommand( command, null, editor, options, toolbarBtnSelector );
                 }
-            }).keyup(hotkey, function (e) {
-                if (editor.attr("contenteditable") && $(editor).is(":visible")) {
+            } ).keyup( hotkey, function( e ) {
+                if ( editor.attr( "contenteditable" ) && $( editor ).is( ":visible" ) ) {
                     e.preventDefault();
                     e.stopPropagation();
                 }
-            });
-        });
+            } );
+        } );
 
-        editor.keyup(function () { editor.trigger("change"); });
-    };
+        editor.keyup( function() { editor.trigger( "change" ); } );
+     };
 
-    Wysiwyg.prototype.getCurrentRange = function () {
+     Wysiwyg.prototype.getCurrentRange = function() {
         var sel, range;
-        if (window.getSelection) {
+        if ( window.getSelection ) {
             sel = window.getSelection();
-            if (sel.getRangeAt && sel.rangeCount) {
-                range = sel.getRangeAt(0);
+            if ( sel.getRangeAt && sel.rangeCount ) {
+                range = sel.getRangeAt( 0 );
             }
-        } else if (document.selection) {
+        } else if ( document.selection ) {
             range = document.selection.createRange();
         }
 
         return range;
-    };
+     };
 
-    Wysiwyg.prototype.saveSelection = function () {
+     Wysiwyg.prototype.saveSelection = function() {
         this.selectedRange = this.getCurrentRange();
-    };
+     };
 
-    Wysiwyg.prototype.restoreSelection = function () {
+     Wysiwyg.prototype.restoreSelection = function() {
         var selection;
-        if (window.getSelection || document.createRange) {
+        if ( window.getSelection || document.createRange ) {
             selection = window.getSelection();
-            if (this.selectedRange) {
+            if ( this.selectedRange ) {
                 try {
                     selection.removeAllRanges();
                 }
-                catch (ex) {
+                catch ( ex ) {
                     document.body.createTextRange().select();
                     document.selection.empty();
                 }
-                selection.addRange(this.selectedRange);
+                selection.addRange( this.selectedRange );
             }
-        } else if (document.selection && this.selectedRange) {
+        } else if ( document.selection && this.selectedRange ) {
             this.selectedRange.select();
         }
-    };
+     };
 
-    // Adding Toggle HTML based on the work by @jd0000, but cleaned up a little to work in this context.
-    Wysiwyg.prototype.toggleHtmlEdit = function (editor) {
-        if (editor.data("wysiwyg-html-mode") !== true) {
+     // Adding Toggle HTML based on the work by @jd0000, but cleaned up a little to work in this context.
+     Wysiwyg.prototype.toggleHtmlEdit = function( editor ) {
+        if ( editor.data( "wysiwyg-html-mode" ) !== true ) {
             var oContent = editor.html();
-            var editorPre = $("<pre />");
-            $(editorPre).append(document.createTextNode(oContent));
-            $(editorPre).attr("contenteditable", true);
-            $(editor).html(" ");
-            $(editor).append($(editorPre));
-            $(editor).attr("contenteditable", false);
-            $(editor).data("wysiwyg-html-mode", true);
-            $(editorPre).focus();
+            var editorPre = $( "<pre />" );
+            $( editorPre ).append( document.createTextNode( oContent ) );
+            $( editorPre ).attr( "contenteditable", true );
+            $( editor ).html( " " );
+            $( editor ).append( $( editorPre ) );
+            $( editor ).attr( "contenteditable", false );
+            $( editor ).data( "wysiwyg-html-mode", true );
+            $( editorPre ).focus();
         } else {
-            $(editor).html($(editor).text());
-            $(editor).attr("contenteditable", true);
-            $(editor).data("wysiwyg-html-mode", false);
-            $(editor).focus();
+            $( editor ).html( $( editor ).text() );
+            $( editor ).attr( "contenteditable", true );
+            $( editor ).data( "wysiwyg-html-mode", false );
+            $( editor ).focus();
         }
-    };
+     };
 
-    Wysiwyg.prototype.insertFiles = function (files, options, editor, toolbarBtnSelector) {
+     Wysiwyg.prototype.insertFiles = function( files, options, editor, toolbarBtnSelector ) {
         var self = this;
         editor.focus();
-        $.each(files, function (idx, fileInfo) {
-            if (/^image\//.test(fileInfo.type)) {
-                $.when(self.readFileIntoDataUrl(fileInfo)).done(function (dataUrl) {
-                    self.execCommand("insertimage", dataUrl, editor, options, toolbarBtnSelector);
-                    editor.trigger("image-inserted");
-                }).fail(function (e) {
-                    options.fileUploadError("file-reader", e);
-                });
+        $.each( files, function( idx, fileInfo ) {
+            if ( /^image\//.test( fileInfo.type ) ) {
+                $.when( self.readFileIntoDataUrl( fileInfo ) ).done( function( dataUrl ) {
+                    self.execCommand( "insertimage", dataUrl, editor, options, toolbarBtnSelector );
+                    editor.trigger( "image-inserted" );
+                } ).fail( function( e ) {
+                    options.fileUploadError( "file-reader", e );
+                } );
             } else {
-                options.fileUploadError("unsupported-file-type", fileInfo.type);
+                options.fileUploadError( "unsupported-file-type", fileInfo.type );
             }
-        });
-    };
+        } );
+     };
 
-    Wysiwyg.prototype.markSelection = function (input, color, options) {
-        this.restoreSelection();
-        if (document.queryCommandSupported("hiliteColor")) {
-            document.execCommand("hiliteColor", false, color || "transparent");
+     Wysiwyg.prototype.markSelection = function( color, options ) {
+        this.restoreSelection(  );
+        if ( document.queryCommandSupported( "hiliteColor" ) ) {
+            document.execCommand( "hiliteColor", false, color || "transparent" );
         }
-        this.saveSelection();
-        //input.data(options.selectionMarker, color);
-    };
+        this.saveSelection(  );
+     };
 
-    Wysiwyg.prototype.bindToolbar = function (editor, toolbar, options, toolbarBtnSelector) {
+     Wysiwyg.prototype.bindToolbar = function( editor, toolbar, options, toolbarBtnSelector ) {
         var self = this;
-        toolbar.find(toolbarBtnSelector).click(function () {
-            self.restoreSelection();
+        toolbar.find( toolbarBtnSelector ).click( function() {
+            self.restoreSelection(  );
             editor.focus();
 
-            if (editor.data(options.commandRole) === "html") {
-                self.toggleHtmlEdit(editor);
+            if ( editor.data( options.commandRole ) === "html" ) {
+                self.toggleHtmlEdit( editor );
             } else {
-                self.execCommand($(this).data(options.commandRole), null, editor, options, toolbarBtnSelector);
+                self.execCommand( $( this ).data( options.commandRole ), null, editor, options, toolbarBtnSelector );
             }
 
-            self.saveSelection();
-        });
+            self.saveSelection(  );
+        } );
 
-        toolbar.find("[data-toggle=dropdown]").on('click', (function () {
-            self.restoreSelection();
-            self.markSelection(null, options.selectionColor, options);
-        }));
+        toolbar.find( "[data-toggle=dropdown]" ).click( this.restoreSelection(  ) );
         
-        toolbar.on("hide.bs.dropdown", function () {
-            self.markSelection(null, false, options);
+        toolbar.on( "hide.bs.dropdown", function () {
+            self.markSelection( null, false, options );
         });
 
-        toolbar.find("input[type=text][data-" + options.commandRole + "]").on("webkitspeechchange change", function () {
+        toolbar.find( "input[type=text][data-" + options.commandRole + "]" ).on( "webkitspeechchange change", function() {
             var newValue = this.value;  // Ugly but prevents fake double-calls due to selection restoration
             this.value = "";
-            self.restoreSelection();
-            if (newValue) {
+            self.restoreSelection(  );
+            if ( newValue ) {
                 editor.focus();
-                self.execCommand($(this).data(options.commandRole), newValue, editor, options, toolbarBtnSelector);
+                self.execCommand( $( this ).data( options.commandRole ), newValue, editor, options, toolbarBtnSelector );
             }
-            self.saveSelection();
-        }).on("focus", function () {
-            console.log('focus');
-            var input = $(this);
-            // if (!input.data(options.selectionMarker)) {
-            //     self.markSelection(input, options.selectionColor, options);
-            // }
-        }).on("blur", function () {
-            console.log('blur');
-            var input = $(this);
-            self.markSelection(input, false, options);
-        });
-        toolbar.find("input[type=file][data-" + options.commandRole + "]").change(function () {
-            self.restoreSelection();
-            if (this.type === "file" && this.files && this.files.length > 0) {
-                self.insertFiles(this.files, options, editor, toolbarBtnSelector);
+            self.saveSelection(  );
+        } ).on( "blur", function() {
+            var input = $( this );
+            if ( input.data( options.selectionMarker ) ) {
+                self.markSelection( input, false, options );
             }
-            self.saveSelection();
+        } );
+        toolbar.find( "input[type=file][data-" + options.commandRole + "]" ).change( function() {
+            self.restoreSelection(  );
+            if ( this.type === "file" && this.files && this.files.length > 0 ) {
+                self.insertFiles( this.files, options, editor, toolbarBtnSelector );
+            }
+            self.saveSelection(  );
             this.value = "";
-        });
-    };
+        } );
+     };
 
-    Wysiwyg.prototype.initFileDrops = function (editor, options, toolbarBtnSelector) {
-        var self = this;
-        editor.on("dragenter dragover", false).on("drop", function (e) {
+     Wysiwyg.prototype.initFileDrops = function( editor, options, toolbarBtnSelector ) {
+         var self = this;
+        editor.on( "dragenter dragover", false ).on( "drop", function( e ) {
             var dataTransfer = e.originalEvent.dataTransfer;
             e.stopPropagation();
             e.preventDefault();
-            if (dataTransfer && dataTransfer.files && dataTransfer.files.length > 0) {
-                self.insertFiles(dataTransfer.files, options, editor, toolbarBtnSelector);
+            if ( dataTransfer && dataTransfer.files && dataTransfer.files.length > 0 ) {
+                self.insertFiles( dataTransfer.files, options, editor, toolbarBtnSelector );
             }
-        });
-    };
+        } );
+     };
 
-    /*
-     *  Represenets an editor
-     *  @constructor
-     *  @param {object} userOptions - The default options selected by the user.
-     */
+     /*
+      *  Represenets an editor
+      *  @constructor
+      *  @param {object} userOptions - The default options selected by the user.
+      */
 
-    $.fn.wysiwyg = function (userOptions) {
-        var wysiwyg = new Wysiwyg(this, userOptions);
-    };
+     $.fn.wysiwyg = function( userOptions ) {
+        var wysiwyg = new Wysiwyg( this, userOptions );
+     };
 
-})(window, window.jQuery);
+} )( window, window.jQuery );

--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -35,7 +35,7 @@
             commandRole: "edit",
             activeToolbarClass: "btn-info",
             selectionMarker: "edit-focus-marker",
-            selectionColor: "red",
+            selectionColor: "darkgrey",
             dragAndDropImages: true,
             keypressTimeout: 200,
             fileUploadError: function (reason, detail) { console.log("File upload error", reason, detail); }
@@ -213,26 +213,6 @@
         }
     };
 
-    Wysiwyg.prototype.restoreSelection2 = function (inputSel) {
-        var selection;
-        if (window.getSelection || document.createRange) {
-            selection = window.getSelection();
-            if (this.selectedRange) {
-                try {
-                    selection.removeAllRanges();
-                }
-                catch (ex) {
-                    //try adding value here for edge when there is no selection
-                    document.body.createTextRange().select();
-                    document.selection.empty();
-                }
-                selection.addRange(inputSel);
-            }
-        } else if (document.selection && inputSel) {
-            inputSel.select();
-        }
-    };
-
     // Adding Toggle HTML based on the work by @jd0000, but cleaned up a little to work in this context.
     Wysiwyg.prototype.toggleHtmlEdit = function (editor) {
         if (editor.data("wysiwyg-html-mode") !== true) {
@@ -299,7 +279,7 @@
             self.markSelection(null, options.selectionColor, options);
         }));
         
-        $(".dropdown").on("hide.bs.dropdown", function () {
+        toolbar.on("hide.bs.dropdown", function () {
             self.markSelection(null, false, options);
         });
 


### PR DESCRIPTION
Instead of calling `markSelection` in focus and clearing browser selection (which will cause issue of losing focus on Edge), we will `markSelection` at the time users click to the hyperlink button. Also always clearing the highlighted selection when bootstrap dropdown closes or losing focus on hyperlink input.