### PR TITLE
Fix iOS 11.4 bug

### DIFF
--- a/src/bootstrap-wysiwyg.js
+++ b/src/bootstrap-wysiwyg.js
@@ -59,6 +59,10 @@
             }.bind( this ) );
 
         $( window ).bind( "touchend", function( e ) {
+            
+            if(!this.getCurrentRange)
+                return;
+            
             var isInside = ( editor.is( e.target ) || editor.has( e.target ).length > 0 ),
             currentRange = this.getCurrentRange(),
             clear = currentRange && ( currentRange.startContainer === currentRange.endContainer && currentRange.startOffset === currentRange.endOffset );


### PR DESCRIPTION
Fix on iOS 11.4 the following error : "this.getCurrentRange is not a function".

I got this error on my webapp when was going from a page with a bootstrap-wysiwg area to another page.